### PR TITLE
fix: error: ‘unique_ptr’ is not a member of ‘std’

### DIFF
--- a/src/HexRaysCodeXplorer/TypeReconstructor.cpp
+++ b/src/HexRaysCodeXplorer/TypeReconstructor.cpp
@@ -28,6 +28,7 @@
 
 #include "Debug.h"
 #include "Utility.h"
+#include <memory>
 
 #if !defined (__LINUX__) && !defined (__MAC__)
 #include <tchar.h>


### PR DESCRIPTION
Hi, using cmake under Linux I had to include the ```<memory>```header in order to use the ```unique_ptr```